### PR TITLE
dns.lua, dns/utils.lua: also look for libknot SONAME 4

### DIFF
--- a/dns.lua
+++ b/dns.lua
@@ -5,7 +5,7 @@ local bit = require('bit')
 local math = require('math')
 local utils = require('dns.utils')
 local n16, n32 = utils.n16, utils.n32
-local knot = utils.clib('libknot', {2,3})
+local knot = utils.clib('libknot', {2,3,4})
 
 ffi.cdef[[
 /*

--- a/dns/utils.lua
+++ b/dns/utils.lua
@@ -49,7 +49,7 @@ function utils.addrparse(s)
 end
 
 -- FFI + C code
-local knot = utils.clib('libknot', {2,3})
+local knot = utils.clib('libknot', {2,3,4})
 local cutil = ffi.load(package.searchpath('kdns_clib', package.cpath))
 ffi.cdef[[
 /* libc */


### PR DESCRIPTION
Hi,

The currently available knot library in Debian has soname 4. Please consider this change.

Cheers,

  -- Santiago

Signed-off-by: Santiago <santiago.ruano-rincon@telecom-bretagne.eu>